### PR TITLE
Remove Suppressor dependency and add JLD dependency

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -11,7 +11,7 @@ Images
 ImageMagick
 Colors
 Interact
-Suppressor
+JLD
 
 # some guis, e.g. photostitching
 GLVisualize

--- a/src/MIT18065.jl
+++ b/src/MIT18065.jl
@@ -1,9 +1,5 @@
 module MIT18065
 
-using Suppressor
-
-@suppress begin
-
 using Images, Colors, Interpolations
 using Polynomials
 using PyCall
@@ -16,8 +12,6 @@ using GLAbstraction, GLVisualize, GLWindow, Reactive, ModernGL, GeometryTypes
 import GLAbstraction: N0f8
 
 using FileIO: @format_str, File, filename, add_format, stream
-
-end
 
 # reexport plotting
 import RecipesBase


### PR DESCRIPTION
The Suppressor package failed in IJulia and will also possibly hide important warning during the migration to 0.6. The course has been using `jls` for data storage but the files can't be read in Julia 0.6 so I've added a dependency on JLD to have a more stable format available. In the future, it should probably be JLD2 but the package is not available in Julia 0.5.